### PR TITLE
fix: standardization of cadastro consumidor payload

### DIFF
--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/controller/CadastroConsumidorController.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/controller/CadastroConsumidorController.java
@@ -6,6 +6,8 @@ import com.es.agriculturafamiliar.dto.cadastroconsumidor.CadastroConsumidorDtoOu
 import com.es.agriculturafamiliar.models.domain.cadastroconsumidor.CadastroConsumidorDomain;
 import com.es.agriculturafamiliar.models.usecase.cadastroconsumidor.CadastroConsumidorUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +18,7 @@ import java.net.URI;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/cadastro/consumidor")
@@ -35,7 +38,10 @@ public class CadastroConsumidorController {
 
         final CadastroConsumidorDtoOut resultado = mapper.toDto(usecaseDomainOut.get());
 
-        return ResponseEntity.created(URI.create("/" + usecaseDomainOut.get().getCpf())).build();
+        log.info(resultado.toString());
+        
+
+        return ResponseEntity.created(URI.create("/" + resultado.getCpf())).body(resultado);
     }
 
     @PutMapping("/{IdCPF}")

--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/cadastroconsumidor/CadastroConsumidorDtoIn.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/cadastroconsumidor/CadastroConsumidorDtoIn.java
@@ -3,12 +3,16 @@ package com.es.agriculturafamiliar.dto.cadastroconsumidor;
 import com.es.agriculturafamiliar.dto.endereco.EnderecoDto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Positive;
 import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,22 +21,18 @@ import java.util.List;
 @Data
 public class CadastroConsumidorDtoIn {
 
-    @NonNull
+    @NotBlank(message = "Nome deve ser preenchido")
     private String nome;
 
-    @NonNull
+    @NotBlank(message = "Email deve ser preenchido")
     private String email;
 
-    @NonNull
-    @Positive(message = "telefone não deve conter números negativos")
-    @Pattern(regexp = "^[0-9]+", message = "telefone deve ser numérico")
+    @NotBlank(message = "Telefone deve ser preenchido")
     private String telefone;
 
-    @NonNull
-    @Positive(message = "cpf não deve conter números negativos")
-    @Pattern(regexp = "^[0-9]+", message = "cpf deve ser numérico")
+    @NotBlank(message = "CPF deve ser preenchido")
     private String cpf;
 
-    @NonNull
-    private List<EnderecoDto> endereco;
+    @NotNull(message ="Uma lista de endereços deve ser fornecido")
+    private List<@Valid EnderecoDto> endereco;
 }

--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/cadastroconsumidor/CadastroConsumidorDtoOut.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/cadastroconsumidor/CadastroConsumidorDtoOut.java
@@ -1,6 +1,23 @@
 package com.es.agriculturafamiliar.dto.cadastroconsumidor;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 public class CadastroConsumidorDtoOut {
+
+    private String nome;
+    private String email;
+    private String telefone;
+    private String cpf;
 
 
 }

--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/endereco/EnderecoDto.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/dto/endereco/EnderecoDto.java
@@ -1,11 +1,12 @@
 package com.es.agriculturafamiliar.dto.endereco;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Positive;
+
 
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,18 +15,14 @@ import javax.validation.constraints.Positive;
 @Data
 public class EnderecoDto {
 
-    @NonNull
+    @NotBlank(message = "Deve-se informar se o endereço é o principal")
     @Pattern(regexp = "(S|N)", message = "o endereço principal só pode receber os valores S ou N")
     private String flagEnderecoPrincipal;
 
-    @NonNull
-    @Positive(message = "CEP não deve conter números negativos")
-    @Pattern(regexp = "^[0-9]+", message = "CEP deve ser numérico")
+    @NotBlank(message = "CEP deve ser preenchido")
     private String cep;
 
-    @NonNull
-    @Positive(message = "Número da residência não deve conter números negativos")
-    @Pattern(regexp = "^[0-9]+", message = "Número da residência deve ser numérico")
+    @NotBlank(message = "Número deve ser preenchido")
     private String numero;
 
     private String complemento;

--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/event/EmailCadastroEvent.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/event/EmailCadastroEvent.java
@@ -1,9 +1,11 @@
 package com.es.agriculturafamiliar.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class EmailCadastroEvent {
     private final String name;

--- a/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/exception/handler/ControllerAdvisor.java
+++ b/backend/agricultura-familiar/src/main/java/com/es/agriculturafamiliar/exception/handler/ControllerAdvisor.java
@@ -13,7 +13,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 
 @RestControllerAdvice

--- a/backend/agricultura-familiar/src/main/resources/db/migration/V1.3.2__fixChangeEnderecoComplementoType.sql
+++ b/backend/agricultura-familiar/src/main/resources/db/migration/V1.3.2__fixChangeEnderecoComplementoType.sql
@@ -1,0 +1,2 @@
+ALTER TABLE endereco_consumidor 
+    MODIFY complemento VARCHAR(100) NOT NULL;

--- a/backend/agricultura-familiar/src/main/resources/templates/registro-produtor.html
+++ b/backend/agricultura-familiar/src/main/resources/templates/registro-produtor.html
@@ -11,7 +11,7 @@
 <body style="margin: 0; padding: 0; font-family: sans-serif; color: #262626;">
     <h3>Olá <span th:text="${name}" />, tudo bem?</h3>
     <br>
-    <p>Recebemos seu pedido cadastro e confirmamos que seu registro foi bem sucedido!</p>
+    <p>Recebemos seu pedido de cadastro e confirmamos que seu registro foi bem sucedido!</p>
     <br>
     <h4>Abraços,</h4>
     <h4>Equipe Muda</h4>

--- a/backend/agricultura-familiar/src/main/resources/templates/registro-produtor.html
+++ b/backend/agricultura-familiar/src/main/resources/templates/registro-produtor.html
@@ -11,7 +11,7 @@
 <body style="margin: 0; padding: 0; font-family: sans-serif; color: #262626;">
     <h3>Olá <span th:text="${name}" />, tudo bem?</h3>
     <br>
-    <p>Recebemos seu de cadastro! Confiramos que seu registro foi bem sucedido</p>
+    <p>Recebemos seu pedido cadastro e confirmamos que seu registro foi bem sucedido!</p>
     <br>
     <h4>Abraços,</h4>
     <h4>Equipe Muda</h4>

--- a/backend/agricultura-familiar/src/test/java/com/es/agriculturafamiliar/controller/ProdutorControllerTests.java
+++ b/backend/agricultura-familiar/src/test/java/com/es/agriculturafamiliar/controller/ProdutorControllerTests.java
@@ -1,12 +1,17 @@
 package com.es.agriculturafamiliar.controller;
 
-import com.es.agriculturafamiliar.controller.ProdutorController;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.es.agriculturafamiliar.entity.produtor.Produtor;
 import com.es.agriculturafamiliar.enums.TipoProdutor;
 import com.es.agriculturafamiliar.repository.EnderecoRepository;
 import com.es.agriculturafamiliar.service.ProdutorService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.Matchers;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,12 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ProdutorController.class)


### PR DESCRIPTION
    more permissive fields to accept front-end masks
    fixing typos of email template
    addition of sending email logic for consumidor sign-up
    
    closes #46 